### PR TITLE
Improved UX and content escaping

### DIFF
--- a/src/tram/tram/static/js/analyze.js
+++ b/src/tram/tram/static/js/analyze.js
@@ -31,7 +31,7 @@ function storeSentences(sentences) {
 }
 
 function renderSentences(active_sentence_id) {
-    var $sentenceTable = $(`<table id="sentence-table" class="table table-striped table-hover"><tbody></tbody></table>`)
+    var $sentenceTable = $(`<table id="sentence-table" class="table table-striped table-hover text-start"><tbody></tbody></table>`)
     for (sentence_id in stored_sentences) {
         sentence = stored_sentences[sentence_id];
         var flag_class = "";
@@ -46,7 +46,7 @@ function renderSentences(active_sentence_id) {
             $row.addClass("bg-info");
         }
         $flag = $(`<td style="width: 1%"></td>`).addClass(flag_class);
-        $text = $(`<td>${sentence.text}</td>`);
+        $text = $(`<td style="word-wrap: break-word;min-width: 160px;max-width: 160px;"></td>`).text(sentence.text);
         $row.append($flag).append($text);
         $sentenceTable.append($row);
     }

--- a/src/tram/tram/templates/analyze.html
+++ b/src/tram/tram/templates/analyze.html
@@ -16,7 +16,7 @@
 <h3 class="display-4 text-center">{{ report_name }}</h3>
 
 <div class="row">
-    <div id="sentence-container" class="col overflow-auto">
+    <div id="sentence-container" class="col overflow-scroll" style="max-height: 500px;">
         <h4>Report Sentences</h4>
         <table id="sentence-table" class="table table-striped table-hover">
             <!-- Contents rendered by JavaScript -->


### PR DESCRIPTION
What changed:

1. Sentence text on /analyze/<id> is now HTML escaped by using `$(`td`).text(sentence.text)` instead of `$(`td ${sentence.text} /td `)`
2. Table text is now left-aligned. It had previously been center-aligned and appeared as if text had not rendered.
3. Table now scrolls and has a max height of 500px