### PR TITLE
fix NoneType found bug when trying to parse text from a pdf

### DIFF
--- a/src/tram/tram/ml/base.py
+++ b/src/tram/tram/ml/base.py
@@ -228,12 +228,7 @@ class SKLearnModel(ABC):
 
     def _extract_pdf_text(self, document):
         with pdfplumber.open(BytesIO(document.docfile.read())) as pdf:
-            page_texts = []
-            for page in pdf.pages:
-                page_text = page.extract_text()
-                if page_text:
-                    page_texts.append(page_text)
-            text = ''.join(page_texts)
+            text = ''.join(page.extract_text() for page in pdf.pages if page.extract_text())
         return text
 
     def _extract_html_text(self, document):

--- a/src/tram/tram/ml/base.py
+++ b/src/tram/tram/ml/base.py
@@ -228,8 +228,12 @@ class SKLearnModel(ABC):
 
     def _extract_pdf_text(self, document):
         with pdfplumber.open(BytesIO(document.docfile.read())) as pdf:
-            text = ''.join(page.extract_text() for page in pdf.pages)
-
+            page_texts = []
+            for page in pdf.pages:
+                page_text = page.extract_text()
+                if page_text:
+                    page_texts.append(page_text)
+            text = ''.join(page_texts)
         return text
 
     def _extract_html_text(self, document):


### PR DESCRIPTION
in some certain cases,  when there are some blank pages or all pictures in a same page in processing pdf document. the parser will raise below exception：
```
Traceback (most recent call last):
  File "<stdin>", line 2, in <module>
TypeError: sequence item 37: expected str instance, NoneType found
```

easy fix steps:
just judge whether the parse result is not none before concat it.