### PR TITLE
fix(ml): skip image-based text when parsing a pdf page

### DIFF
--- a/src/tram/tram/ml/base.py
+++ b/src/tram/tram/ml/base.py
@@ -228,7 +228,12 @@ class SKLearnModel(ABC):
 
     def _extract_pdf_text(self, document):
         with pdfplumber.open(BytesIO(document.docfile.read())) as pdf:
-            text = ''.join(page.extract_text() for page in pdf.pages)
+            page_texts = []
+            for page in pdf.pages:
+                page_text = page.extract_text()
+                if page_text:
+                    page_texts.append(page_text)
+            text = ''.join(page_texts)
 
         return text
 

--- a/tests/tram/test_base.py
+++ b/tests/tram/test_base.py
@@ -298,8 +298,8 @@ class TestsThatNeedTrainingData:
         Some PDFs can be saved such that the text is stored as images and therefore
         cannot be extracted from the PDF. Windows PDF Printer behaves this way.
 
-        Image-based PDFs cause the processing pipeline to fail. The expected behavior
-        is that the job is logged as "status: error".
+        Image-based PDFs are skipped by the processing pipeline. The expected behavior
+        is that the document processing job completes without logging "status: error".
         """
         # Arrange
         image_pdf = 'tests/data/GroupIB_Big_Airline_Heist_APT41.pdf'
@@ -310,11 +310,10 @@ class TestsThatNeedTrainingData:
 
         # Act
         model_manager.run_model()
-        job_result = db_models.DocumentProcessingJob.objects.get(id=job_id)
+        is_processed = not db_models.DocumentProcessingJob.objects.filter(id=job_id).exists()
 
         # Assert
-        assert job_result.status == 'error'
-        assert len(job_result.message) > 0
+        assert is_processed
 
     """
     ----- Begin DummyModel Tests -----


### PR DESCRIPTION
# What Changed

- The processing pipeline will skip image-based text when parsing a pdf page

# Known Limitations

None
