### PR TITLE
Refactor get_training_data for simplicity

### DIFF
--- a/src/tram/tram/ml/base.py
+++ b/src/tram/tram/ml/base.py
@@ -52,10 +52,8 @@ class Report(object):
 
 class SKLearnModel(ABC):
     """
-    Mark D TODO:
+    TODO:
     1. Move text extraction and tokenization out of the SKLearnModel
-    2. Combine _laod_and_vectorize, _preprocess_text, and get_training_data into a single
-       get_training_data that returns a lemmatized X, y tuple
     """
     def __init__(self):
         self._technique_ids = None

--- a/src/tram/tram/models.py
+++ b/src/tram/tram/models.py
@@ -1,5 +1,6 @@
 import os
 
+from constance import config
 from django.contrib.auth.models import User
 from django.core.files import File
 from django.db import models
@@ -143,6 +144,14 @@ class Mapping(models.Model):
 
     def __str__(self):
         return 'Sentence "%s" to %s' % (self.sentence, self.attack_technique)
+
+    @classmethod
+    def get_accepted_mappings(cls):
+        # Get Attack techniques that have the required amount of positive examples
+        attack_techniques = AttackTechnique.get_sentence_counts(accept_threshold=config.ML_ACCEPT_THRESHOLD)
+        # Get mappings for the attack techniques above threshold
+        mappings = Mapping.objects.filter(attack_technique__in=attack_techniques)
+        return mappings
 
 
 class MLSettings(models.Model):

--- a/tests/tram/test_base.py
+++ b/tests/tram/test_base.py
@@ -168,10 +168,11 @@ class TestSkLearnModel:
 
     def test_no_data_get_training_data_succeeds(self, dummy_model):
         # Act
-        training_data = dummy_model.get_training_data()
+        X, y = dummy_model.get_training_data()
 
         # Assert
-        assert len(training_data) == 0
+        assert len(X) == 0
+        assert len(y) == 0
 
     def test_get_training_data_returns_only_accepted_sentences(self, dummy_model, report):
         # Arrange
@@ -198,14 +199,14 @@ class TestSkLearnModel:
         config.ML_ACCEPT_THRESHOLD = 0  # Set the threshold to 0 for this test
 
         # Act
-        training_data = dummy_model.get_training_data()
+        X, y = dummy_model.get_training_data()
         s1.delete()
         s2.delete()
         m1.delete()
 
         # Assert
-        assert len(training_data) == 1
-        assert training_data[0].__class__ == base.Sentence
+        assert len(X) == 1
+        assert len(y) == 1
 
     def test_non_sklearn_pipeline_raises(self):
         # Arrange


### PR DESCRIPTION
This change is to simplify how training data is retrieved from the database so that future improvements are easier. I ran this locally and the application behaved as expected. For manual testing, I trained a model and uploaded reports.

What changed:

- get_training_data now returns an X, y tuple instead of objects. The X, y tuple has better ergonomics for the SKLearn pipeline
- test() and train() both call get_training_data() directly
- Removed dead code (y_counts) in SKLearnModel.test
- Deleted SKLearnModel._load_and_vectorize_data. It has been replaced by the improved get_training_data().
- Replaced _preprocess_text() with lemmatize().
  - Input changed from a list of sentences to a single sentence
  - Output changed from a list of lemmatized sentences to a single lemmatized sentence

Limitations:

- Project test coverage dropped by 0.15% because I deleted covered lines.