### PR TITLE
refactor(ci, build): Simplify build process and developer workflow for running tests and container builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+# exclude items not needed/conflict on docker image
+
+.github
+venv
+.venv

--- a/.github/workflows/build-push-container.yml
+++ b/.github/workflows/build-push-container.yml
@@ -3,7 +3,15 @@
 name: Publish Docker image on publish of release
 
 on:
-  workflow_dispatch:  
+  push:
+    branches:
+      - master
+      - refactor/docker_tweaks
+  pull_request:
+    branches:
+      - master
+      - refactor/docker_tweaks
+  workflow_dispatch:
   release:
     types: [published]
 

--- a/.github/workflows/build-push-container.yml
+++ b/.github/workflows/build-push-container.yml
@@ -1,0 +1,40 @@
+# Will automatically build and push new docker image on release
+
+name: Publish Docker image on publish of release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  push_to_registries:
+    name: Push Docker image to multiple registries
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: |
+            ghcr.io/${{ github.repository }}
+
+#      - name: Build and push Docker images
+#        uses: docker/build-push-action@@v2
+#        with:
+#          context: .
+#          push: true
+#          tags: ${{ steps.meta.outputs.tags }}
+#          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build-push-container.yml
+++ b/.github/workflows/build-push-container.yml
@@ -5,6 +5,7 @@ name: Publish Docker image on publish of release
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 jobs:
   push_to_registries:

--- a/.github/workflows/build-push-container.yml
+++ b/.github/workflows/build-push-container.yml
@@ -3,9 +3,9 @@
 name: Publish Docker image on publish of release
 
 on:
+  workflow_dispatch:  
   release:
     types: [published]
-  workflow_dispatch:
 
 jobs:
   push_to_registries:

--- a/.github/workflows/build-push-container.yml
+++ b/.github/workflows/build-push-container.yml
@@ -3,21 +3,12 @@
 name: Publish Docker image on publish of release
 
 on:
-  push:
-    branches:
-      - master
-      - refactor/docker_tweaks
-  pull_request:
-    branches:
-      - master
-      - refactor/docker_tweaks
-  workflow_dispatch:
   release:
     types: [published]
 
 jobs:
   push_to_registries:
-    name: Push Docker image to multiple registries
+    name: Push Docker image to multiple registries if necessary
     runs-on: ubuntu-latest
     permissions:
       packages: write
@@ -39,11 +30,13 @@ jobs:
         with:
           images: |
             ghcr.io/${{ github.repository }}
+          labels: |
+            org.opencontainers.image.url=https://ctid.mitre-engenuity.org/our-work/tram/
 
-#      - name: Build and push Docker images
-#        uses: docker/build-push-action@@v2
-#        with:
-#          context: .
-#          push: true
-#          tags: ${{ steps.meta.outputs.tags }}
-#          labels: ${{ steps.meta.outputs.labels }}
+      - name: Build and push Docker images
+        uses: docker/build-push-action@@v2
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -11,7 +11,7 @@ name: Lint Code Base
 #############################
 on:
   pull_request:
-    branches: [develop, master]
+    branches: [master]
 
 ###############
 # Set the Job #

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -10,8 +10,6 @@ name: Lint Code Base
 # Start the job on all push #
 #############################
 on:
-  push:
-    # branches-ignore: [main]
   pull_request:
     branches: [develop, master]
 
@@ -38,7 +36,7 @@ jobs:
         env:
           LINTER_RULES_PATH: /
           VALIDATE_ALL_CODEBASE: false
-          DEFAULT_BRANCH: develop
+          DEFAULT_BRANCH: master
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PYTHON_BLACK_CONFIG_FILE: "pyproject.toml"
           PYTHON_ISORT_CONFIG_FILE: "pyproject.toml"

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,0 +1,55 @@
+---
+#################################
+#################################
+## Super Linter GitHub Actions ##
+#################################
+#################################
+name: Lint Code Base
+
+#############################
+# Start the job on all push #
+#############################
+on:
+  push:
+    # branches-ignore: [main]
+  pull_request:
+    branches: [develop, master]
+
+###############
+# Set the Job #
+###############
+jobs:
+  build:
+    name: Lint Code Base
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+        with:
+          # Full git history is needed to get a proper list of changed files within `super-linter`
+          fetch-depth: 0
+
+      ################################
+      # Run Linter against code base #
+      ################################
+      - name: Lint Code Base
+        uses: github/super-linter/slim@v4
+        env:
+          LINTER_RULES_PATH: /
+          VALIDATE_ALL_CODEBASE: false
+          DEFAULT_BRANCH: develop
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PYTHON_BLACK_CONFIG_FILE: "pyproject.toml"
+          PYTHON_ISORT_CONFIG_FILE: "pyproject.toml"
+          SHELLCHECK_OPTS: "-e SC2016 -e SC2086 -e SC2129"
+          VALIDATE_BASH: true
+          VALIDATE_BASH_EXEC: true
+          VALIDATE_DOCKERFILE_HADOLINT: true
+          VALIDATE_GITHUB_ACTIONS: true
+          VALIDATE_PYTHON: true
+          VALIDATE_PYTHON_BLACK: true
+          VALIDATE_PYTHON_FLAKE8: true
+          VALIDATE_PYTHON_ISORT: true
+          VALIDATE_SHELL_SHFMT: true
+          VALIDATE_TERRAFORM_TFLINT: true

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,55 @@ __pycache__
 !.gitkeep
 db.sqlite3
 *.pem
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .idea
 __pycache__
 *env
+.venv
 *.pkl
 /data/object_store
 /data/models/*

--- a/.gitignore
+++ b/.gitignore
@@ -29,9 +29,6 @@ __pypackages__/
 
 # Environments
 .env
-.venv
-env/
-venv/
 ENV/
 env.bak/
 venv.bak/

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 .idea
 __pycache__
 *env
-.venv
 *.pkl
 /data/object_store
 /data/models/*

--- a/.gitignore
+++ b/.gitignore
@@ -27,8 +27,6 @@ db.sqlite3
 __pypackages__/
 
 # Environments
-.env
-ENV/
 env.bak/
 venv.bak/
 

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,4 @@
+
+ignored:
+  - DL3008 # disable apt package pinning check
+  - DL3042 # disable no-cache-dir pip check as cache is used with docker cache volume

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,26 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.0.1
+    hooks:
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: debug-statements
+      - id: check-toml
+  - repo: https://github.com/psf/black
+    rev: 21.11b1
+    hooks:
+      - id: black
+  - repo: https://github.com/jumanjihouse/pre-commit-hooks
+    rev: 2.1.5 # or specific git tag
+    hooks:
+      - id: shellcheck
+      - id: shfmt
+        args:
+          - -i
+          - "4"
+  - repo: https://github.com/pycqa/isort
+    rev: 5.10.1
+    hooks:
+      - id: isort
+        name: isort (python)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,21 +6,21 @@ Thanks for contributing to TRAM!
 
 You are welcome to comment on issues, open new issues, and open pull requests.
 
-Pull requests should target the **develop** branch of the repository.
+Pull requests should target the **master** branch of the repository.
 
 Also, if you contribute any source code, we need you to agree to the following Developer's Certificate of Origin below.
 
 ## Reporting Issues
-  
+
 * Describe (in detail) what should have happened. Include any supporting information that may be helpful in resolving the issue.
-  
+
 * Be sure to include any steps to replicate the issue.
 
 ## Submission Guidelines
 
 You are welcome to comment on issues, open new issues, and open pull requests.
 
-Pull requests should target the **develop** branch of the repository.
+Pull requests should target the **master** branch of the repository.
 
 Also, if you contribute any source code, we need you to agree to the following Developer's Certificate of Origin below.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,8 +36,12 @@ RUN mkdir /tram && \
     python3 -m venv /tram/.venv && \
     /tram/.venv/bin/python3 -m pip install -U pip wheel setuptools
 
+# add venv to path
 ENV LC_ALL=C.UTF-8 LANG=C.UTF-8 \
     PATH=/tram/.venv/bin:${PATH}
+
+# flush all output immediately
+ENV PYTHONUNBUFFERED 1
 
 WORKDIR /tram
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,8 +33,8 @@ RUN --mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/
         python3-wheel
 
 RUN mkdir /tram && \
-    python -m venv /tram/.venv && \
-    /tram/.venv/bin/python -m pip install -U pip wheel setuptools
+    python3 -m venv /tram/.venv && \
+    /tram/.venv/bin/python3 -m pip install -U pip wheel setuptools
 
 ENV LC_ALL=C.UTF-8 LANG=C.UTF-8 \
     PATH=/tram/.venv/bin:${PATH}
@@ -47,7 +47,7 @@ COPY ./ .
 
 # install app dependencies
 RUN  --mount=type=cache,target=/root/.cache \
-    python -m pip install -r ./requirements/requirements.txt && \
+    python3 -m pip install -r ./requirements/requirements.txt && \
     cp -f ./docker/entrypoint.sh entrypoint.sh
 
 EXPOSE 8000

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,8 +48,11 @@ COPY ./ .
 # install app dependencies
 RUN  --mount=type=cache,target=/root/.cache \
     python3 -m pip install -r ./requirements/requirements.txt && \
-    cp -f ./docker/entrypoint.sh entrypoint.sh
+    cp -f ./docker/entrypoint.sh entrypoint.sh && \
+    # Download NLTK data
+    python3 -m nltk.downloader punkt && \
+    python3 -m nltk.downloader wordnet
 
 EXPOSE 8000
 
-ENTRYPOINT [ "entrypoint.sh" ]
+ENTRYPOINT [ "/tram/entrypoint.sh" ]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,80 @@
+#
+# See `make help` for a list of all available commands.
+#
+
+APP_NAME := tram
+VENV := venv
+BIN := $(VENV)/bin
+PY_VERSION := python3.9
+TIMESTAMP := $(shell date -u +"%Y%m%d_%H%M%S")
+GIT_HASH := $(shell git rev-parse --short HEAD)
+
+.DEFAULT_GOAL := help
+
+.PHONY: help
+help:
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+# the aliasing for the venv target is done primarily for readability
+$(VENV): $(BIN)/activate
+
+venv: $(VENV)  ## build python venv
+
+$(BIN)/activate:
+	$(PY_VERSION) -m venv --prompt $(APP_NAME) $(VENV)
+
+.PHONY: install
+install: venv  upgrade-pip ## Install Python dependencies
+	./$(BIN)/python -m pip install -r requirements/requirements.txt
+
+.PHONY: install-dev
+install-dev: venv upgrade-pip  ## Install Python dependencies and dev dependencies
+	./$(BIN)/python -m pip install -r requirements/requirements.txt
+	./$(BIN)/python -m pip install -r requirements/test-requirements.txt
+
+.PHONY: upgrade-pip
+upgrade-pip: venv  ## Upgrade pip and related
+	./$(BIN)/python -m pip install --upgrade pip wheel setuptools pip-tools
+
+.git/hooks/pre-commit: install-dev
+	./$(BIN)/pre-commit install
+
+.PHONY: pre-commit-run
+pre-commit-run: venv .git/hooks/pre-commit ## Run pre-commit manually on changed files
+	./$(BIN)/pre-commit run
+
+.PHONY: pre-commit-run-all
+pre-commit-run-all: venv .git/hooks/pre-commit ## Run pre-commit manually on all files
+	./$(BIN)/pre-commit run -a
+
+.PHONY: build-container
+build-container: venv ## Build container image
+	docker build -t $(APP_NAME):dev -t $(APP_NAME):$(TIMESTAMP)_$(GIT_HASH) -f Dockerfile . --label "org.opencontainers.image.revision=$(GIT_HASH)"
+
+.PHONY: clean
+clean: ## Clean up pycache files
+	find . -name '*.pyc' -delete
+	find . -name '__pycache__' -type d -delete
+
+.PHONY: clean-all
+clean-all: clean ## Clean up venv and tox if necessary, in addition to standard clean
+	find . \( -name ".tox" -o -name "$(VENV)" -o -name "*.egg-info"  \) -type d -prune -exec rm -rf {} +
+	find ./src -name '*.egg' -delete
+	rm -f coverage.xml
+
+.PHONY: venv-activate
+venv-activate: venv ## Activate venv
+	@echo "Activate your virtualenv by running the following command: "
+	@echo "source $(BIN)/activate"
+
+.PHONY: venv-deactivate
+venv-deactivate: ## Deactivate venv
+	@echo "Activate your virtualenv by running the following command: "
+	@echo "source deactivate"
+
+.PHONY: lint
+lint: pre-commit-run ## Lint code
+
+.PHONY: test
+test: venv ## Run tests
+	./$(BIN)/python -m tox

--- a/Makefile
+++ b/Makefile
@@ -76,5 +76,5 @@ venv-deactivate: ## Deactivate venv
 lint: pre-commit-run ## Lint code
 
 .PHONY: test
-test: venv ## Run tests
+test: venv install-dev ## Run tests
 	./$(BIN)/python -m tox

--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,9 @@
 #
 
 APP_NAME := tram
-VENV := venv
+VENV := .venv
 BIN := $(VENV)/bin
-PY_VERSION := python3.9
+PY_VERSION := python3
 TIMESTAMP := $(shell date -u +"%Y%m%d_%H%M%S")
 GIT_HASH := $(shell git rev-parse --short HEAD)
 
@@ -24,7 +24,7 @@ $(BIN)/activate:
 	$(PY_VERSION) -m venv --prompt $(APP_NAME) $(VENV)
 
 .PHONY: install
-install: venv  upgrade-pip ## Install Python dependencies
+install: venv upgrade-pip ## Install Python dependencies
 	./$(BIN)/python -m pip install -r requirements/requirements.txt
 
 .PHONY: install-dev

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,21 @@ pre-commit-run-all: venv .git/hooks/pre-commit ## Run pre-commit manually on all
 build-container: venv ## Build container image
 	docker build -t $(APP_NAME):dev -t $(APP_NAME):$(TIMESTAMP)_$(GIT_HASH) -f Dockerfile . --label "org.opencontainers.image.revision=$(GIT_HASH)"
 
+.PHONY: start-container
+start-container: ## Start container via docker-compose, runs ctidorg/tram:latest image by default
+	docker-compose -f docker/docker-compose.yml up -d
+	@echo "Waiting for container to start..."
+	@echo "To stop the container, run: make stop-container, or, docker-compose -f docker/docker-compose.yml down"
+	@echo "To view container logs, run make container-logs, or, docker-compose -f docker/docker-compose.yml logs -f"
+
+.PHONY: stop-container
+stop-container: ## Stop container via docker-compose
+	docker-compose -f docker/docker-compose.yml down
+
+.PHONY: container-logs
+container-logs: ## Print container logs
+	docker-compose -f docker/docker-compose.yml logs -f
+
 .PHONY: clean
 clean: ## Clean up pycache files
 	find . -name '*.pyc' -delete

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Through research into automating the mapping of cyber threat intel reports to AT
     - [[97438] Failed to execute script docker-compose](#97438-failed-to-execute-script-docker-compose)
   - [Requirements](#requirements)
   - [Developer Setup](#developer-setup)
+    - [Makefile Version](#makefile-version)
   - [Machine Learning Development](#machine-learning-development)
     - [Existing ML Models](#existing-ml-models)
     - [Creating Your Own Model](#creating-your-own-model)
@@ -113,6 +114,26 @@ cd tram/
 source venv/bin/activate
 python src/tram/manage.py pipeline run
 ```
+
+### Makefile Version
+
+* Build Python virtualenv
+  * `make venv`
+* Install all development dependencies
+  * `make install-dev`
+* Activate newly created virtualenv
+  * `source .venv/bin/activate`
+* Setup pre-commit (required one-time process per local `git clone` repository)
+  * `pre-commit install`
+* Manually run pre-commit hooks without performing a commit
+  * `make pre-commit-run`
+* Build container image (By default, container is tagged with timestamp and git hash of codebase)
+  * `make build-container`
+* Run linting locally
+  * `make lint`
+* Run unit tests, safety, and bandit locally
+  * `make test`
+
 ## Machine Learning Development
 All source code related to machine learning is located in TRAM
 [src/tram/tram/ml](https://github.com/center-for-threat-informed-defense/tram/tree/master/src/tram/tram/ml).

--- a/README.md
+++ b/README.md
@@ -4,18 +4,24 @@
 
 Threat Report ATT&CK Mapping (TRAM) is an open-source platform designed to advance research into automating the mapping of cyber threat intelligence reports to MITRE ATT&CK®.
 
-TRAM enables researchers to test and refine Machine Learning (ML) models for identifying ATT&CK techniques in prose-based cyber threat intel reports and allows threat intel analysts to train ML models and validate ML results. 
+TRAM enables researchers to test and refine Machine Learning (ML) models for identifying ATT&CK techniques in prose-based cyber threat intel reports and allows threat intel analysts to train ML models and validate ML results.
 
 Through research into automating the mapping of cyber threat intel reports to ATT&CK, TRAM aims to reduce the cost and increase the effectiveness of integrating ATT&CK into cyber threat intelligence across the community. Threat intel providers, threat intel platforms, and analysts should be able to use TRAM to integrate ATT&CK more easily and consistently into their products.
 
 ## Table of contents
-* [Installation](#installation)
-* [Installation Troubleshooting](#installation-troubleshooting)
-* [Requirements](#requirements)
-* [Developer Setup](#developer-setup)
-* [Machine Learning Development](#machine-learning-development)
-* [Contribute](#how-do-i-contribute)
-* [Notice](#notice)
+- [TRAM](#tram)
+  - [Table of contents](#table-of-contents)
+  - [Installation](#installation)
+  - [Installation Troubleshooting](#installation-troubleshooting)
+    - [[97438] Failed to execute script docker-compose](#97438-failed-to-execute-script-docker-compose)
+  - [Requirements](#requirements)
+  - [Developer Setup](#developer-setup)
+  - [Machine Learning Development](#machine-learning-development)
+    - [Existing ML Models](#existing-ml-models)
+    - [Creating Your Own Model](#creating-your-own-model)
+  - [How do I contribute?](#how-do-i-contribute)
+    - [Contribute Training Data](#contribute-training-data)
+  - [Notice](#notice)
 
 ## Installation
 1. Get Docker: https://docs.docker.com/get-docker/
@@ -23,7 +29,7 @@ Through research into automating the mapping of cyber threat intel reports to AT
 3. Ensure Docker is running. On some operating systems (e.g., MacOS), you will need to provide Docker with permissions before proceeding.
 4. Download docker-compose.yml (view raw, save as)
 ```
-https://github.com/center-for-threat-informed-defense/tram/blob/master/docker/docker-compose.yml
+https://github.com/center-for-threat-informed-defense/tram/releases/download/v1.0.0/docker-compose.yml
 ```
 3. If desired, edit the settings in `docker-compose.yml`
 4. Navigate to the directory where you saved `docker-compose.yml`
@@ -97,7 +103,7 @@ python src/tram/manage.py createsuperuser
 ```
 Run the webserver
 ```
-python src/tram/manage.py runserver 
+python src/tram/manage.py runserver
 ```
 Then you can navigate to http://localhost:8000 and use the superuser to log in
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Through research into automating the mapping of cyber threat intel reports to AT
   - [Requirements](#requirements)
   - [Developer Setup](#developer-setup)
     - [Makefile Version](#makefile-version)
+      - [Useful User Commands](#useful-user-commands)
+      - [Useful Dev Commands](#useful-dev-commands)
   - [Machine Learning Development](#machine-learning-development)
     - [Existing ML Models](#existing-ml-models)
     - [Creating Your Own Model](#creating-your-own-model)
@@ -116,6 +118,18 @@ python src/tram/manage.py pipeline run
 ```
 
 ### Makefile Version
+
+#### Useful User Commands
+
+* Run TRAM application
+  * `make start-container`
+* Stop TRAM application
+  * `make stop-container`
+* View TRAM logs
+  * `make container-logs`
+
+
+#### Useful Dev Commands
 
 * Build Python virtualenv
   * `make venv`

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,19 +1,19 @@
-# TRAM compose file. 
+# TRAM compose file.
 #  - TRAM is currently setup to use Django with SQLite DB
 #  - TRAM currently only works from localhost on port 8000 (or whatever port you select here)
-#  - Any ML data and DB data is stored at the path stored in the environment variable 
+#  - Any ML data and DB data is stored at the path stored in the environment variable
 #    `DATA_DIRECTORY`. This is internal to Django.
 #  - ALLOWED_HOSTS is a list of hosts allowed to connect to the Django server (in settings.py)
 #  - SECRET_KEY is a URL Safe Token and should be changed
 version: '3.5'
 services:
   tram:
-    image: ctidorg/tram:latest
+    image: ghcr.io/center-for-threat-informed-defense/tram:latest
     ports:
       - "8000:8000"
     environment:
       - DATA_DIRECTORY=/tram/data
-      - ALLOWED_HOSTS=["example_host1", "localhost"] 
+      - ALLOWED_HOSTS=["example_host1", "localhost"]
       - SECRET_KEY=Ij0WGee73k9OESwqddmSKCx6SY9aJ_7bDojs485Z6ec # your secret key here
       - DEBUG=True
       - DJANGO_SUPERUSER_USERNAME=djangoSuperuser
@@ -22,4 +22,4 @@ services:
     volumes:
       - tram:/tram/data
 volumes:
-  tram:    
+  tram:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -32,7 +32,7 @@ python3 /tram/src/tram/manage.py makemigrations tram
 python3 /tram/src/tram/manage.py migrate
 
 # Used provided superuser credentials to create a superuser
-if [[ "${SKIP_CREATE_SUPERUSER}" -ne 0 ]]; then
+if [[ "${SKIP_CREATE_SUPERUSER}" -eq 0 ]]; then
 
     PY_CREATE_SU_SCRIPT="
 from django.contrib.auth.models import User;

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -50,10 +50,6 @@ else:
     printf "%s" "${PY_CREATE_SU_SCRIPT}" | python3 /tram/src/tram/manage.py shell
 fi
 
-# Download NLTK data
-python3 -m nltk.downloader punkt
-python3 -m nltk.downloader wordnet
-
 # Run ML processes
 python3 /tram/src/tram/manage.py attackdata load
 python3 /tram/src/tram/manage.py pipeline load-training-data

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,8 +1,4 @@
-#!/bin/bash
-
-# Run Django migrations scripts
-python3  /tram/src/tram/manage.py makemigrations tram
-python3  /tram/src/tram/manage.py migrate
+#!/usr/bin/env bash
 
 # Create a super user for the Django server
 #   This should be set by ENV and must include:
@@ -10,13 +6,60 @@ python3  /tram/src/tram/manage.py migrate
 #      - DJANGO_SUPERUSER_PASSWORD
 #      - DJANGO_SUPERUSER_EMAIL
 
-python3 /tram/src/tram/manage.py createsuperuser --noinput
-python3 -c "import nltk; nltk.download('punkt'); nltk.download('wordnet')"
+# Set SKIP_CREATE_SUPERUSER to 1 to skip creating the super user on every run
+
+# check for required environment variables
+SKIP_CREATE_SUPERUSER=${SKIP_CREATE_SUPERUSER:-0}
+
+# only check for required variables if we are not skipping the creation of the superuser
+if [ "${SKIP_CREATE_SUPERUSER}" -eq 0 ]; then
+    if [[ -z "${DJANGO_SUPERUSER_USERNAME:+x}" ]]; then
+        echo "Environment variable DJANGO_SUPERUSER_USERNAME is not set. Skipping superuser creation."
+        SKIP_CREATE_SUPERUSER=1
+    fi
+    if [[ -z "${DJANGO_SUPERUSER_PASSWORD:+x}" ]]; then
+        echo "Environment variable DJANGO_SUPERUSER_PASSWORD is not set. Skipping superuser creation."
+        SKIP_CREATE_SUPERUSER=1
+    fi
+    if [[ -z "${DJANGO_SUPERUSER_EMAIL:+x}" ]]; then
+        echo "Environment variable DJANGO_SUPERUSER_EMAIL is not set. Skipping superuser creation."
+        SKIP_CREATE_SUPERUSER=1
+    fi
+fi
+
+# Generate and Run Django migrations scripts
+python3 /tram/src/tram/manage.py makemigrations tram
+python3 /tram/src/tram/manage.py migrate
+
+# Used provided superuser credentials to create a superuser
+if [[ "${SKIP_CREATE_SUPERUSER}" -ne 0 ]]; then
+
+    PY_CREATE_SU_SCRIPT="
+from django.contrib.auth.models import User;
+
+username = '$DJANGO_SUPERUSER_USERNAME';
+password = '$DJANGO_SUPERUSER_PASSWORD';
+email = '$DJANGO_SUPERUSER_EMAIL';
+
+if not User.objects.filter(username = username).exists():
+    User.objects.create_superuser(username, email, password);
+    print('Superuser created.');
+else:
+    print('Superuser creation skipped, user already exists.');
+"
+    printf "%s" "${PY_CREATE_SU_SCRIPT}" | python3 /tram/src/tram/manage.py shell
+fi
+
+# Download NLTK data
+python3 -m nltk.downloader punkt
+python3 -m nltk.downloader wordnet
+
+# Run ML processes
 python3 /tram/src/tram/manage.py attackdata load
 python3 /tram/src/tram/manage.py pipeline load-training-data
 python3 /tram/src/tram/manage.py pipeline train --model nb
 python3 /tram/src/tram/manage.py pipeline train --model logreg
 nohup python3 /tram/src/tram/manage.py pipeline run --model logreg &
 
-# Run the server on Loopback using port 8000
+# Run Django on port 8000
 python3 /tram/src/tram/manage.py runserver 0.0.0.0:8000

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,14 @@
+[tool.black]
+exclude = '''
+/(
+  \.mypy_cache
+  | \.venv
+  | venv
+  | migrations
+  | node_modules
+)/
+'''
+
+[tool.isort]
+profile = "black"
+multi_line_output = 3

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,11 +1,11 @@
 beautifulsoup4==4.9.3
-django==3.2.6
 django-constance==2.8.0
 django-picklefield==3.0.1
-django-rest-framework
+django-rest-framework==0.1.0
+django==3.2.6
 faker==6.5.0
-pdfplumber==0.5.27
-python-docx==0.8.10
 nltk==3.6.5
 pandas==1.2.3
+pdfplumber==0.5.27
+python-docx==0.8.10
 scikit-learn==0.24.1

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -2,7 +2,7 @@ beautifulsoup4==4.9.3
 django-constance==2.8.0
 django-picklefield==3.0.1
 django-rest-framework==0.1.0
-django==3.2.6
+django==3.2.10
 faker==6.5.0
 nltk==3.6.5
 pandas==1.2.3

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -1,9 +1,10 @@
 bandit==1.7.0
+flake8>=3.5
 pytest
 pytest-cov==2.11.1
 pytest-django==4.1.0
 pytest-flake8==1.0.7
-flake8>=3.5
-pytest-pythonpath
 pytest-mock==3.5.1
+pytest-pythonpath
 safety==1.10.3
+tox==3.24.5

--- a/tox.ini
+++ b/tox.ini
@@ -35,6 +35,7 @@ commands =
 max-line-length = 120
 indent-size = 4
 max-complexity = 20
+extend-ignore = E203
 exclude =
     src/archive
     src/tram/tram/migrations


### PR DESCRIPTION
## What Changed

PR adds some automation and shortcuts to simplify common developer/user usage scenarios and best practices.

* Release Process
  * When a release on the github repository is created, the container will automatically be built and pushed to the Github Container Registry with the version set to the tag, in addition to a `latest` tag.

* Linting
  * Adds automatic linting locally (via pre-commit), in CI (via super-linter). 
  * Adds pre-commit configuration for local running of standard linting tasks (see .pre-commit-config.yaml for details)
  * CI will report on each individual linter separately to easily identify any linting failures (Dockerfiles, shell scripts, python, etc.)
* Makefile
  * Adds Makefile to simplify/standardize setup, build, and usage of product
  * Targets for the following
    * container build (`make build-container`, automatically adds OCI label with git hash to built image), 
    * venv creation (`make venv`),
    * test execution (`make test`, via tox),
    * list all make targets and description (either `make help` or `make` with no arguments will print summary of make targets available)
* Container 
  * Adds check for existing user from entrypoint script, to avoid cycle of overwriting user credentials on subsequent container restarts
  * Django superuser is created on first start
  * Uses module syntax of downloading nltk data (no functional changes)
  * Moves nltk download to dockerfile (from entrypoint)
  * Adds industry-standard [OCI labels](https://github.com/opencontainers/image-spec/blob/main/annotations.md) to Dockerfile, includes reference URL for info, repo URL, description, license, and git hash when built via Makefile
  * Adds `.dockerignore`
  * Updates Dockerfile to use buildkit
  * Use cache volumes in Dockerfile for apt/pip to speed up subsequent builds
* Docs
  * Adds Add Makefile usage notes to README
  * Update `CONTRIBUTING.md` doc to reference `master` branch (`develop` branch does not exist on repo)
  * Updates `docker-compose.yml` link in README to point to specific release within git (ties to specific release of file, and makes file location independent from repository structure and branch)
* Misc
  * add tox to test-requirements file
  * alphabetize python requirements, a sort a day keeps the ocd away
  * pin version of `django-rest-framework` to allow scanning by safety
  * Update ignore files to add coverage files and other standard git ignores

## Limitations

* Training data still duplicated on subsequent startups. If not desired, may want to consider ome of the following to resolve: 
  * Bundle attackdata loading and initial train into Dockerfile, or
  * Modify pipeline command to add an option/alternative command to only load data if not previously loaded
  * Add standalone database to Docker compose configuration, and do training in separate container instance, so training can be controlled/scaled/modified independent of the web application 