### PR TITLE
CI-Build Fix

### DIFF
--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -1,6 +1,6 @@
 bandit==1.7.0
 flake8>=3.5
-pytest
+pytest<7.0.0
 pytest-cov==2.11.1
 pytest-django==4.1.0
 pytest-flake8==1.0.7


### PR DESCRIPTION
The new major release of `pytest` causing problems, this PR restricts pytest version to use on the build.