### PR TITLE
Fix Docker ML pipeline

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -50,7 +50,7 @@ else:
     printf "%s" "${PY_CREATE_SU_SCRIPT}" | python3 /tram/src/tram/manage.py shell
 fi
 
-nohup python3 /tram/src/tram/manage.py pipeline run --model logreg &
+nohup python3 /tram/src/tram/manage.py pipeline run --model logreg --run-forever &
 
 # Run Django on port 8000
 # python3 /tram/src/tram/manage.py runserver 0.0.0.0:8000


### PR DESCRIPTION
## What Changed?

- The pipeline process when specified without the `--run-forever` flag will die out immediately if there are no jobs to process or when the jobs are finished processing. This causes any jobs submitted using Docker to stay in `Queued` state for ever and are only processed when restarted.

New docker images will be needed for the update to address users that make use of the published images.

closes #131
closes #114