### PR TITLE
[CTID-18] Provide user information for uploads

### DIFF
--- a/src/tram/tram/ml/base.py
+++ b/src/tram/tram/ml/base.py
@@ -351,6 +351,7 @@ class ModelManager(object):
             document=document,
             text=report.text,
             ml_model=self.model.__class__.__name__,
+            created_by=document.created_by,
         )
         rpt.save()
 

--- a/src/tram/tram/models.py
+++ b/src/tram/tram/models.py
@@ -88,11 +88,12 @@ class DocumentProcessingJob(models.Model):
     updated_on = models.DateTimeField(auto_now=True)
 
     @classmethod
-    def create_from_file(cls, f):
+    def create_from_file(cls, f, u):
         assert isinstance(f, File)
-        doc = Document(docfile=f)
+        assert isinstance(u, User)
+        doc = Document(docfile=f, created_by=u)
         doc.save()
-        dpj = DocumentProcessingJob(document=doc)
+        dpj = DocumentProcessingJob(document=doc, created_by=u)
         dpj.save()
         return dpj
 

--- a/src/tram/tram/serializers.py
+++ b/src/tram/tram/serializers.py
@@ -197,7 +197,7 @@ class ReportExportSerializer(ReportSerializer):
                 document=None,
                 text=validated_data["text"],
                 ml_model=validated_data["ml_model"],
-                created_by=None,  # TODO: Get user from session
+                created_by=validated_data["created_by"],
             )
 
             for sentence in validated_data["sentences"]:

--- a/src/tram/tram/views.py
+++ b/src/tram/tram/views.py
@@ -99,13 +99,13 @@ def upload(request):
         "text/html",  # .html files
         "application/vnd.openxmlformats-officedocument.wordprocessingml.document",  # .docx files
     ):
-        DocumentProcessingJob.create_from_file(request.FILES["file"])
+        DocumentProcessingJob.create_from_file(request.FILES["file"], request.user)
     elif file_content_type in ("application/json",):  # .json files
         json_data = json.loads(request.FILES["file"].read())
         res = serializers.ReportExportSerializer(data=json_data)
 
         if res.is_valid():
-            res.save()
+            res.save(created_by=request.user)
         else:
             return HttpResponseBadRequest(res.errors)
     else:


### PR DESCRIPTION
## What Changed?
- This PR provides current user (from web request) to populate `created_by`
- For manual submissions using the pipeline command create/uses a generic user

![image](https://user-images.githubusercontent.com/8574582/153409465-c5912d78-77e7-4a1e-a65c-f27f10904014.png)

closes #83