### PR TITLE
refactor(logs): Set up Django logging to replace existing print()'s

### DIFF
--- a/src/scripts/reformat_training_data.py
+++ b/src/scripts/reformat_training_data.py
@@ -29,6 +29,7 @@ The target format is defined by tram.serializers.ReportExportSerializer
 """
 
 import json
+import logging
 import os
 import sys
 from datetime import datetime
@@ -42,7 +43,10 @@ django.setup()
 
 from tram.serializers import ReportExportSerializer  # noqa: E402
 
+
 outfile = "data/training/bootstrap-training-data.json"
+logger = logging.getLogger(__name__)
+
 
 ATTACK_LOOKUP = {  # A mapping of attack descriptions to technique IDs
     "drive-by compromise": "T1189",
@@ -289,7 +293,7 @@ def main():
     with open(outfile, "w") as f:
         json.dump(res.initial_data, f, indent=4)
 
-    print("Wrote data to %s" % outfile)
+    logger.info("Wrote data to %s" % outfile)
 
 
 if __name__ == "__main__":

--- a/src/scripts/reformat_training_data.py
+++ b/src/scripts/reformat_training_data.py
@@ -43,7 +43,6 @@ django.setup()
 
 from tram.serializers import ReportExportSerializer  # noqa: E402
 
-
 outfile = "data/training/bootstrap-training-data.json"
 logger = logging.getLogger(__name__)
 

--- a/src/tram/tram/management/commands/attackdata.py
+++ b/src/tram/tram/management/commands/attackdata.py
@@ -6,7 +6,6 @@ from django.core.management.base import BaseCommand
 
 from tram.models import AttackObject
 
-
 LOAD = "load"
 CLEAR = "clear"
 logger = logging.getLogger(__name__)

--- a/src/tram/tram/management/commands/attackdata.py
+++ b/src/tram/tram/management/commands/attackdata.py
@@ -1,12 +1,15 @@
 import json
+import logging
 
 from django.conf import settings
 from django.core.management.base import BaseCommand
 
 from tram.models import AttackObject
 
+
 LOAD = "load"
 CLEAR = "clear"
+logger = logging.getLogger(__name__)
 
 
 STIX_TYPE_TO_ATTACK_TYPE = {
@@ -35,7 +38,7 @@ class Command(BaseCommand):
 
     def clear_attack_data(self):
         deleted = AttackObject.objects.all().delete()
-        print(f"Deleted {deleted[0]} Attack objects")
+        logger.info("Deleted %d Attack objects", deleted[0])
 
     def create_attack_object(self, obj):
         for external_reference in obj["external_references"]:
@@ -106,11 +109,11 @@ class Command(BaseCommand):
             except ValueError:  # Value error means unsupported object type
                 skipped_stats[obj_type] = skipped_stats.get(obj_type, 0) + 1
 
-        print(f"Load stats for {filepath}:")
+        logger.info("Load stats for %s:", filepath)
         for k, v in created_stats.items():
-            print(f"\tCreated {v} {k} objects")
+            logger.info("Created %s %s objects", v, k)
         for k, v in skipped_stats.items():
-            print(f"\tSkipped {v} {k} objects")
+            logger.info("Skipped %s %s objects", v, k)
 
     def handle(self, *args, **options):
         subcommand = options["subcommand"]

--- a/src/tram/tram/management/commands/pipeline.py
+++ b/src/tram/tram/management/commands/pipeline.py
@@ -1,3 +1,4 @@
+import logging
 import json
 import time
 
@@ -8,10 +9,12 @@ import tram.models as db_models
 from tram import serializers
 from tram.ml import base
 
+
 ADD = "add"
 RUN = "run"
 TRAIN = "train"
 LOAD_TRAINING_DATA = "load-training-data"
+logger = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
@@ -55,12 +58,12 @@ class Command(BaseCommand):
             with open(filepath, "rb") as f:
                 django_file = File(f)
                 db_models.DocumentProcessingJob.create_from_file(django_file)
-            self.stdout.write(f"Added file to ML Pipeline: {filepath}")
+            logger.info("Added file to ML Pipeline: %s", filepath)
             return
 
         if subcommand == LOAD_TRAINING_DATA:
             filepath = options["file"]
-            self.stdout.write(f"Loading training data from {filepath}")
+            logger.info("Loading training data from %s", filepath)
             with open(filepath, "r") as f:
                 res = serializers.ReportExportSerializer(data=json.load(f))
                 res.is_valid(raise_exception=True)
@@ -71,13 +74,13 @@ class Command(BaseCommand):
         model_manager = base.ModelManager(model)
 
         if subcommand == RUN:
-            self.stdout.write(f"Running ML Pipeline with Model: {model}")
+            logger.info("Running ML Pipeline with Model: %s", model)
             return model_manager.run_model(options["run_forever"])
         elif subcommand == TRAIN:
-            self.stdout.write(f"Training ML Model: {model}")
+            logger.info("Training ML Model: %s", model)
             start = time.time()
             return_value = model_manager.train_model()
             end = time.time()
             elapsed = end - start
-            self.stdout.write(f"Trained ML model in {elapsed} seconds")
+            logger.info("Trained ML model in %0.3f seconds", elapsed)
             return return_value

--- a/src/tram/tram/management/commands/pipeline.py
+++ b/src/tram/tram/management/commands/pipeline.py
@@ -1,5 +1,5 @@
-import logging
 import json
+import logging
 import time
 
 from django.core.files import File
@@ -8,7 +8,6 @@ from django.core.management.base import BaseCommand
 import tram.models as db_models
 from tram import serializers
 from tram.ml import base
-
 
 ADD = "add"
 RUN = "run"

--- a/src/tram/tram/ml/base.py
+++ b/src/tram/tram/ml/base.py
@@ -1,8 +1,8 @@
+import logging
 import pathlib
 import pickle
 import re
 import time
-import traceback
 from abc import ABC, abstractmethod
 from datetime import datetime, timezone
 from io import BytesIO
@@ -26,6 +26,9 @@ from sklearn.pipeline import Pipeline
 
 # The word model is overloaded in this scope, so a prefix is necessary
 from tram import models as db_models
+
+
+logger = logging.getLogger(__name__)
 
 
 class Sentence(object):
@@ -346,10 +349,10 @@ class ModelManager(object):
         model_filepath = self.get_model_filepath(model_class)
         if path.exists(model_filepath):
             self.model = model_class.load_from_file(model_filepath)
-            print("%s loaded from %s" % (model_class.__name__, model_filepath))
+            logger.info("%s loaded from %s", model_class.__name__, model_filepath)
         else:
             self.model = model_class()
-            print("%s loaded from __init__" % model_class.__name__)
+            logger.info("%s loaded from __init__", model_class.__name__)
 
     def _save_report(self, report, document):
         rpt = db_models.Report(
@@ -393,19 +396,18 @@ class ModelManager(object):
             ).order_by("created_on")
             for job in jobs:
                 filename = job.document.docfile.name
-                print("Processing Job #%d: %s" % (job.id, filename))
+                logger.info("Processing Job #%d: %s", job.id, filename)
                 try:
                     report = self.model.process_job(job)
                     with transaction.atomic():
                         self._save_report(report, job.document)
                         job.delete()
-                    print("Created report %s" % report.name)
+                    logger.info("Created report %s", report.name)
                 except Exception as ex:
                     job.status = "error"
                     job.message = str(ex)
                     job.save()
-                    print(f"Failed to create report for {filename}.")
-                    print(traceback.format_exc())
+                    logger.exception("Failed to create report for %s.", filename)
 
             if not run_forever:
                 return
@@ -420,7 +422,7 @@ class ModelManager(object):
         self.model.test()
         filepath = self.get_model_filepath(self.model.__class__)
         self.model.save_to_file(filepath)
-        print("Trained model saved to %s" % filepath)
+        logger.info("Trained model saved to %s" % filepath)
         return
 
     @staticmethod

--- a/src/tram/tram/ml/base.py
+++ b/src/tram/tram/ml/base.py
@@ -27,7 +27,6 @@ from sklearn.pipeline import Pipeline
 # The word model is overloaded in this scope, so a prefix is necessary
 from tram import models as db_models
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/src/tram/tram/settings.py
+++ b/src/tram/tram/settings.py
@@ -49,6 +49,40 @@ else:
 
 DATA_UPLOAD_MAX_NUMBER_FIELDS = None
 
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "tram_formatter": {
+            "format": "[{asctime}] {levelname} [{name}] {message}",
+            "datefmt": "%Y-%m-%d %H:%M:%S",
+            "style": "{",
+        },
+    },
+    "handlers": {
+        "tram_handler": {
+            "class": "logging.StreamHandler",
+            "formatter": "tram_formatter",
+        },
+    },
+    "loggers": {
+        "root": {
+            "handlers": ["tram_handler"],
+            "level": "WARNING",
+        },
+        "django": {
+            "handlers": ["tram_handler"],
+            "level": "INFO",
+            "propagate": False,
+        },
+        "tram": {
+            "handlers": ["tram_handler"],
+            "level": "INFO",
+            "propagate": False,
+        },
+    },
+}
+
 # Application definition
 
 INSTALLED_APPS = [


### PR DESCRIPTION
While getting familiar with the project, I noticed there are a lot of print() and sys.stdout.write() scattered throughout the code. This PR sets up logging using the standard Django approach.

Before:

```
$ python src/tram/manage.py pipeline run
LogisticRegressionModel loaded from /Volumes/Code/ctid/tram/data/ml-models/LogisticRegressionModel.pkl
Running ML Pipeline with Model: logreg
Processing Job #18: lorem_4bGyFhK.pdf
Created report Report for lorem_4bGyFhK.pdf
```

After:

```
$ python src/tram/manage.py pipeline run
[2022-02-11 18:49:18] INFO [tram.ml.base] LogisticRegressionModel loaded from /Volumes/Code/ctid/tram/data/ml-models/LogisticRegressionModel.pkl
[2022-02-11 18:49:18] INFO [tram.management.commands.pipeline] Running ML Pipeline with Model: logreg
[2022-02-11 18:49:18] INFO [tram.ml.base] Processing Job #18: lorem_4bGyFhK.pdf
[2022-02-11 18:49:18] INFO [tram.ml.base] Created report Report for lorem_4bGyFhK.pdf
```