### PR TITLE
refactor(auth): Persist the SECRET_KEY

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,4 @@
+[run]
+omit =
+    src/tram/tram/settings.py
+    src/tram/tram/migrations/*

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 __pycache__
 *env
 *.pkl
+/data/django.key
 /data/object_store
 /data/models/*
 /data/ml-source

--- a/src/tram/tram/settings.py
+++ b/src/tram/tram/settings.py
@@ -31,10 +31,21 @@ else:
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/3.1/howto/deployment/checklist/
 
-# SECURITY WARNING: keep the secret key used in production secret!
-# Default will regenerate secret key on every startup. To use a static secret key,
-# set the SECRET_KEY env variable.
-SECRET_KEY = os.getenv("SECRET_KEY", get_random_secret_key())
+# SECURITY WARNING: keep the secret key used in production secret! The secret
+# key can be provided in the SECRET_KEY environment variable. Otherwise, the key
+# is generated on first run and saved in the data directory.
+SECRET_KEY = os.getenv("SECRET_KEY")
+
+if SECRET_KEY is None:
+    SECRET_KEY_PATH = DATA_DIRECTORY / "django.key"
+    try:
+        with SECRET_KEY_PATH.open() as secret_key_file:
+            SECRET_KEY = secret_key_file.read()
+    except FileNotFoundError:
+        SECRET_KEY = get_random_secret_key()
+        with SECRET_KEY_PATH.open("w") as secret_key_file:
+            secret_key_file.write(SECRET_KEY)
+
 
 # SECURITY WARNING: don't run with debug turned on in production!
 if os.environ.get("DEBUG") is not None:

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ commands =
     python -m nltk.downloader punkt
     python -m nltk.downloader wordnet
     python -m nltk.downloader omw-1.4
-    pytest --cov=src/ --cov=src/tram --cov=src/tram/tram/ml --cov=src/tram/tram/management/commands --cov-report=xml
+    pytest --cov=tram --cov-report=xml
 
 [testenv:bandit]
 description = Bandit Security Checks


### PR DESCRIPTION
During development, every time you save a source file it reloads the
Django server which generates a new SECRET_KEY which means you have to
log in again, which is extremely tedious. This commit saves the
generated key to the data directory so that it can be reused.

Also modified code coverage to exclude `settings.py` and migrations.