### PR TITLE
[CTID-29] Add a "Close Button" on the Analyze Page

### DIFF
--- a/src/tram/templates/analyze.html
+++ b/src/tram/templates/analyze.html
@@ -11,6 +11,10 @@
 </script>
 {% endblock %}
 
+{% block back-to-index-link %}
+<a class="btn btn btn-outline-light" href="/">Close Report</a>
+{% endblock %}
+
 {% block body %}
 
 <h3 class="display-4 text-center">{{ report_name }}</h3>

--- a/src/tram/templates/base.html
+++ b/src/tram/templates/base.html
@@ -39,7 +39,9 @@
             </h1>
             <ul class="navbar-nav d-flex m-0">
                 <li class="navbar-item me-1">
+                    {% block back-to-index-link %}
                     <a class="btn btn btn-outline-light" href="/">Reports</a>
+                    {% endblock %}
                 </li>
                 <li class="navbar-item me-1">
                     <a class="btn btn btn-outline-light" href="/ml">ML Admin</a>


### PR DESCRIPTION
## What Changed?

- Enclose the link used to go back to the index page inside a block (opposed to using JS to update the element on the client side)
 - The block will be used to modify its content on the analyze page to provide a button with more relevant text.

There are a few UX changes that could be made based on recommendation on this PR:
- Use different text like "Save & Close", "Close", "Close Report", "Save Report", "Back", others?
- Use different classes to change the look like be button be solid, outline with different color, particular color of interest (red?)

![image](https://user-images.githubusercontent.com/8574582/155357597-b148cc6c-c9f9-4406-902c-5f61cddaec21.png)

closes #92 