### PR TITLE
docs(README): Add instructions for airgap deployment (fixes #104)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,10 @@ LABEL "org.opencontainers.image.license"="Apache-2.0"
 ARG TRAM_CA_URL
 ARG TRAM_CA_THUMBPRINT
 
+# Change default shell to bash so that we can use pipes (|) safely. See:
+# https://github.com/hadolint/hadolint/wiki/DL4006
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
 # Install and update apt dependencies
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
@@ -53,7 +57,7 @@ RUN if test -n "${TRAM_CA_URL}" -a -n "${TRAM_CA_THUMBPRINT}" ; then \
         if test "${DOWNLOAD_CA_THUMBPRINT}" = "${TRAM_CA_THUMBPRINT}"; then \
             update-ca-certificates; \
         else \
-            echo "\n=====\nERROR\nExpected thumbprint: ${TRAM_CA_THUMBPRINT}\nActual thumbprint:   ${DOWNLOAD_CA_THUMBPRINT}\n=====\n"; \
+            printf "\n=====\nERROR\nExpected thumbprint: %s\nActual thumbprint:   %s\n=====\n" "${TRAM_CA_THUMBPRINT}" "${DOWNLOAD_CA_THUMBPRINT}"; \
             exit 1; \
         fi; \
     fi

--- a/Makefile
+++ b/Makefile
@@ -49,9 +49,11 @@ pre-commit-run-all: venv .git/hooks/pre-commit ## Run pre-commit manually on all
 
 .PHONY: build-container
 build-container: venv ## Build container image
-	docker build -t $(APP_NAME):dev -t $(APP_NAME):$(TIMESTAMP)_$(GIT_HASH) -f Dockerfile . --label "org.opencontainers.image.revision=$(GIT_HASH)"
-	docker build -t $(APP_NAME)-nginx:dev -t $(APP_NAME)-nginx:$(TIMESTAMP)_$(GIT_HASH) -f docker/Dockerfile.nginx . --label "org.opencontainers.image.revision=$(GIT_HASH)"
-
+	docker build -t $(APP_NAME):dev -t $(APP_NAME):$(TIMESTAMP)_$(GIT_HASH) \
+		-f Dockerfile . --label "org.opencontainers.image.revision=$(GIT_HASH)" \
+		--build-arg TRAM_CA_URL=$(TRAM_CA_URL) --build-arg TRAM_CA_THUMBPRINT=$(TRAM_CA_THUMBPRINT)
+	docker build -t $(APP_NAME)-nginx:dev -t $(APP_NAME)-nginx:$(TIMESTAMP)_$(GIT_HASH) \
+		-f docker/Dockerfile.nginx . --label "org.opencontainers.image.revision=$(GIT_HASH)"
 
 .PHONY: start-container
 start-container: ## Start container via docker-compose, runs ctidorg/tram:latest image by default


### PR DESCRIPTION
- Provide detailed steps for how to move Docker images across an airgap.
- The rest of the installation is the same.
- Also refactor the way we build certs into the Docker image. The old approach
  required editing the dockerfile, which led certain people (<cough> me) to
  accidentally check in the Dockerfile with their own issuer cert configured in
  it. The new approach passes the information in the environment.
  
  closes #104 