### PR TITLE
Enable creation of AttackObject in Django admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ containerized version is recommended for non-developers.
 10. Run the application server
 
     ```sh
-    DEBUG=1 tram runserver
+    DJANGO_DEBUG=1 tram runserver
     ```
 
 11. Open the application in your web browser.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -16,7 +16,6 @@ services:
     environment:
       - DATA_DIRECTORY=/tram/data
       - ALLOWED_HOSTS=["example_host1", "localhost"]
-      - DEBUG=True
       - DJANGO_SUPERUSER_USERNAME=djangoSuperuser
       - DJANGO_SUPERUSER_PASSWORD=LEGITPassword1234 # your password here
       - DJANGO_SUPERUSER_EMAIL=test@example.com # your email address here

--- a/src/tram/admin.py
+++ b/src/tram/admin.py
@@ -28,7 +28,7 @@ class SentenceInline(admin.TabularInline):
 
 
 class AttackObjectAdmin(admin.ModelAdmin):
-    readonly_fields = ("name", "stix_id", "attack_id", "attack_url", "matrix")
+    pass
 
 
 class DocumentAdmin(admin.ModelAdmin):

--- a/src/tram/settings.py
+++ b/src/tram/settings.py
@@ -48,8 +48,9 @@ if SECRET_KEY is None:
 
 
 # SECURITY WARNING: don't run with debug turned on in production!
-if os.environ.get("DEBUG") is not None:
-    DEBUG = bool(os.environ.get("DEBUG").lower() in ["true", "1", "t", "yes", "y"])
+_django_debug_env = os.environ.get("DJANGO_DEBUG")
+if _django_debug_env is not None:
+    DEBUG = _django_debug_env.lower() in ["true", "1", "t", "yes", "y"]
 else:
     DEBUG = False
 


### PR DESCRIPTION
Not sure why these fields were marked as readonly, but it prevents any meaningful usage of the AttackObject admin UI. Opening this PR as a draft so I can get some feedback on whether this breaks anything else. (Fixes #163)