### PR TITLE
Adds endpoint for fetching reports by using document IDs.

### DIFF
--- a/src/tram/views.py
+++ b/src/tram/views.py
@@ -6,10 +6,10 @@ from urllib.parse import quote
 from constance import config
 from django.contrib.auth.decorators import login_required
 from django.http import (
-    JsonResponse,
     Http404,
     HttpResponse,
     HttpResponseBadRequest,
+    JsonResponse,
     StreamingHttpResponse,
 )
 from django.shortcuts import render
@@ -156,7 +156,7 @@ def upload(request):
     dpj = None
 
     # Initialize response.
-    response = {'message': 'File saved for processing.'}
+    response = {"message": "File saved for processing."}
 
     file_content_type = request.FILES["file"].content_type
     if file_content_type in (
@@ -165,7 +165,9 @@ def upload(request):
         "application/vnd.openxmlformats-officedocument.wordprocessingml.document",  # .docx files
         "text/plain",  # .txt files
     ):
-        dpj = DocumentProcessingJob.create_from_file(request.FILES["file"], request.user)
+        dpj = DocumentProcessingJob.create_from_file(
+            request.FILES["file"], request.user
+        )
     elif file_content_type in ("application/json",):  # .json files
         json_data = json.loads(request.FILES["file"].read())
         res = serializers.ReportExportSerializer(data=json_data)
@@ -178,8 +180,8 @@ def upload(request):
         return HttpResponseBadRequest("Unsupported file type")
 
     if dpj:
-        response['job-id'] = dpj.pk
-        response['doc-id'] = dpj.document.pk
+        response["job-id"] = dpj.pk
+        response["doc-id"] = dpj.document.pk
 
     return JsonResponse(response)
 

--- a/src/tram/views.py
+++ b/src/tram/views.py
@@ -6,6 +6,7 @@ from urllib.parse import quote
 from constance import config
 from django.contrib.auth.decorators import login_required
 from django.http import (
+    JsonResponse,
     Http404,
     HttpResponse,
     HttpResponseBadRequest,
@@ -154,8 +155,8 @@ def upload(request):
     # Initialize the processing job.
     dpj = None
 
-    # Initialize headers.
-    headers = {}
+    # Initialize response.
+    response = {'message': 'File saved for processing.'}
 
     file_content_type = request.FILES["file"].content_type
     if file_content_type in (
@@ -177,9 +178,10 @@ def upload(request):
         return HttpResponseBadRequest("Unsupported file type")
 
     if dpj:
-        headers.update({'job-id': dpj.pk, 'doc-id': dpj.document.pk})
+        response['job-id'] = dpj.pk
+        response['doc-id'] = dpj.document.pk
 
-    return HttpResponse("File saved for processing", headers=headers, status=200)
+    return JsonResponse(response)
 
 
 @login_required

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import json
 import tempfile
 from pathlib import Path
 
@@ -89,6 +90,28 @@ def report(document):
     """
     yield models.Report.objects.get(id=1)
 
+
+@pytest.fixture
+def report_with_document(document):
+    """
+    This fixture is used for testing fetching reports when document id is given.
+    """
+    with open("tests/data/simple-test.docx", "rb") as f:
+        d = models.Document(docfile=File(f))
+        d.save()
+    with open("tests/data/report-for-simple-testdocx.json", "rb") as f:
+        j = json.loads(f.read())
+        r = models.Report(
+            name=j['name'],
+            document=d,
+            text=j['text'],
+            ml_model=j['ml_model'],
+            created_on=j['created_on'],
+            updated_on=j['updated_on'])
+        r.save()
+    yield r
+    r.delete()
+    d.delete()
 
 @pytest.fixture
 def document_processing_job(document):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -102,16 +102,18 @@ def report_with_document(document):
     with open("tests/data/report-for-simple-testdocx.json", "rb") as f:
         j = json.loads(f.read())
         r = models.Report(
-            name=j['name'],
+            name=j["name"],
             document=d,
-            text=j['text'],
-            ml_model=j['ml_model'],
-            created_on=j['created_on'],
-            updated_on=j['updated_on'])
+            text=j["text"],
+            ml_model=j["ml_model"],
+            created_on=j["created_on"],
+            updated_on=j["updated_on"],
+        )
         r.save()
     yield r
     r.delete()
     d.delete()
+
 
 @pytest.fixture
 def document_processing_job(document):

--- a/tests/tram/test_views.py
+++ b/tests/tram/test_views.py
@@ -311,9 +311,7 @@ class TestReportExport:
     def test_get_reports_by_doc_id(self, logged_in_client, report_with_document):
         # Act
         doc_id = report_with_document.document.id
-        response = logged_in_client.get(
-            f"/api/report-export/?doc-id={doc_id}"
-        )
+        response = logged_in_client.get(f"/api/report-export/?doc-id={doc_id}")
         json_response = json.loads(response.content)
 
         # Assert

--- a/tests/tram/test_views.py
+++ b/tests/tram/test_views.py
@@ -308,6 +308,17 @@ class TestReportExport:
         # Assert
         assert response.content == b"test file content"
 
+    def test_get_reports_by_doc_id(self, logged_in_client, report_with_document):
+        # Act
+        doc_id = report_with_document.document.id
+        response = logged_in_client.get(
+            f"/api/report-export/?doc-id={doc_id}"
+        )
+        json_response = json.loads(response.content)
+
+        # Assert
+        assert json_response[0]["document_id"] == doc_id
+
 
 @pytest.mark.django_db
 class TestMl:


### PR DESCRIPTION
This pull requests adds an endpoint for fetching reports created for certain documents. 

> Closes #166.

- Document ID and Job ID is returned in headers from `upload` method.
- This way, users accessing TRAM not via GUI can track the progress of the jobs created for their uploaded documents.
  - *They can also get all the reports created for these documents.*
 > `/api/report-export/?doc-id=<DOC_ID>`