### PR TITLE
Add an API route to trigger [re-]training of models (#124)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: debug-statements
       - id: check-toml
   - repo: https://github.com/psf/black
-    rev: 21.11b1
+    rev: 22.3.0
     hooks:
       - id: black
   - repo: https://github.com/jumanjihouse/pre-commit-hooks

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -2,6 +2,7 @@ beautifulsoup4==4.9.3
 django-constance==2.8.0
 django-picklefield==3.0.1
 django-rest-framework==0.1.0
+djangorestframework-simplejwt==5.1.0
 django==3.2.12
 faker==6.5.0
 gunicorn==20.1.0

--- a/src/tram/settings.py
+++ b/src/tram/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/3.1/ref/settings/
 """
 
 import os
+from datetime import timedelta
 from json import loads
 from pathlib import Path
 
@@ -209,9 +210,18 @@ STATIC_ROOT = BASE_DIR / "staticfiles"
 MEDIA_ROOT = os.path.join(DATA_DIRECTORY, "media")
 
 REST_FRAMEWORK = {
+    "DEFAULT_AUTHENTICATION_CLASSES": [
+        "rest_framework.authentication.SessionAuthentication",
+        "rest_framework_simplejwt.authentication.JWTAuthentication",
+    ],
     "DEFAULT_PERMISSION_CLASSES": [
         "rest_framework.permissions.IsAuthenticated",
-    ]
+    ],
+}
+
+SIMPLE_JWT = {
+    "ACCESS_TOKEN_LIFETIME": timedelta(hours=1),
+    "REFRESH_TOKEN_LIFETIME": timedelta(days=1),
 }
 
 ML_MODEL_DIR = os.path.join(DATA_DIRECTORY, "ml-models")

--- a/src/tram/urls.py
+++ b/src/tram/urls.py
@@ -20,6 +20,7 @@ from django.contrib.auth import views as auth_views
 from django.urls import include, path
 from django.views.generic.base import TemplateView
 from rest_framework.routers import DefaultRouter
+from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 
 from tram import views
 
@@ -36,7 +37,10 @@ urlpatterns = [
     path("", views.index),
     path("analyze/<int:pk>/", views.analyze),
     path("api/", include(router.urls)),
+    path("api/token/", TokenObtainPairView.as_view(), name="token_obtain_pair"),
+    path("api/token/refresh/", TokenRefreshView.as_view(), name="token_refresh"),
     path("api/download/<int:doc_id>", views.download_document),
+    path("api/train-model/<name>", views.train_model),
     path("docs/", TemplateView.as_view(template_name="tram_documentation.html")),
     path("login/", auth_views.LoginView.as_view()),
     path("logout/", auth_views.LogoutView.as_view()),

--- a/tests/tram/test_views.py
+++ b/tests/tram/test_views.py
@@ -340,3 +340,17 @@ class TestMl:
 
         # Assert
         assert response.status_code == 404  # HTTP 200 Ok
+
+    def test_train_model(self, logged_in_client):
+        # Act
+        response = logged_in_client.post("/api/train-model/dummy")
+
+        # Assert
+        assert response.status_code == 200  # HTTP 200 Ok
+
+    def test_train_model_404(self, logged_in_client):
+        # Act
+        response = logged_in_client.post("/api/train-model/doesnt-exist")
+
+        # Assert
+        assert response.status_code == 404  # HTTP 404 Not Found


### PR DESCRIPTION
Add an API route to trigger training of a model. This runs synchronously and the current implementation is a stop gap until a point in time where we could have training run asynchronously (e.g. background workers reading a message queue). 

Adapted from @bsnyder70's PR #129. Unlike the PR, this implementation does not have a GUI component because the synchronous aspect of the API call would lead to high latency in the GUI (e.g. click the button and it freezes for 10-15 seconds while it trains the model). For now training can only be triggered from an API call (or from the command line, which has not changed in this PR).

TRAM doesn't really have an API authentication scheme. The "API" routes use the cookie-based authentication and the Django views require CSRF tokens, which is inconvenient for API calls. So this PR also adds JWT tokens (described in the README) so that API calls can be made with a bearer token and no CSRF token. This is still backwards compatible with session/CSRF auth, so it shouldn't break any existing API clients out there.