### PR TITLE
Fix JSON export for reports (#175)

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ docker.errors.DockerException: Error while fetching server API version: ('Connec
 [97438] Failed to execute script docker-compose
 ```
 
-Then most likely Docker is not running and you need to start Docker.
+Then most likely reason is that Docker is not running and you need to start it.
 
 ## Report Troubleshooting
 

--- a/src/tram/renderers.py
+++ b/src/tram/renderers.py
@@ -1,0 +1,29 @@
+import io
+
+from rest_framework import renderers
+
+import tram.report.docx
+
+
+class DocxReportRenderer(renderers.BaseRenderer):
+    """This custom renderer exports mappings into Word .docx format."""
+
+    media_type = (
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+    )
+    format = "docx"
+
+    def render(self, data, accepted_media_type=None, renderer_context=None):
+        """
+        Export report mappings into Word .docx format.
+
+        :param data: the report mappings dict
+        :param accepted_media_type: the content type negotiated by DRF
+        :param renderer_context: optional additional data
+        :returns bytes: .docx binary data
+        """
+        document = tram.report.docx.build(data)
+        buffer = io.BytesIO()
+        document.save(buffer)
+        buffer.seek(0)
+        return buffer.read()

--- a/src/tram/templates/index.html
+++ b/src/tram/templates/index.html
@@ -71,10 +71,8 @@
               Export
             </button>
             <div class="dropdown-menu" aria-labelledby="export-dropdown">
-              <a class="dropdown-item btn btn-sm btn-outline-secondary"
-                href="/api/report-export/{{ report.id }}/?type=json">JSON</a>
-              <a class="dropdown-item btn btn-sm btn-outline-secondary"
-                href="/api/report-export/{{ report.id }}/?type=docx">DOCX</a>
+              <a class="dropdown-item btn btn-sm btn-outline-secondary" href="{% url 'report-mapping-detail' report.id %}?format=json">JSON</a>
+              <a class="dropdown-item btn btn-sm btn-outline-secondary" href="{% url 'report-mapping-detail' report.id %}?format=docx">DOCX</a>
             </div>
           </div>
           {% if report.document_id is not None %}

--- a/src/tram/urls.py
+++ b/src/tram/urls.py
@@ -29,7 +29,9 @@ router.register(r"attack", views.AttackObjectViewSet)
 router.register(r"jobs", views.DocumentProcessingJobViewSet)
 router.register(r"mappings", views.MappingViewSet)
 router.register(r"reports", views.ReportViewSet)
-router.register(r"report-export", views.ReportExportViewSet)
+router.register(
+    r"report-mappings", views.ReportMappingViewSet, basename="report-mapping"
+)
 router.register(r"sentences", views.SentenceViewSet)
 
 

--- a/src/tram/views.py
+++ b/src/tram/views.py
@@ -15,8 +15,8 @@ from django.http import (
 )
 from django.shortcuts import render
 from django.views.decorators.http import require_POST
-from rest_framework import viewsets
-from rest_framework.decorators import api_view
+from rest_framework import renderers, viewsets
+from rest_framework.decorators import action, api_view
 from rest_framework.response import Response
 
 import tram.report.docx

--- a/tests/tram/test_views.py
+++ b/tests/tram/test_views.py
@@ -254,28 +254,28 @@ class TestSentenceViewSet:
 
 
 @pytest.mark.django_db
-class TestReportExport:
-    def test_get_report_export_succeeds(self, logged_in_client, mapping):
+class TestReportMappings:
+    def test_get_json(self, logged_in_client, mapping):
         # Act
-        response = logged_in_client.get("/api/report-export/1/")
+        response = logged_in_client.get("/api/report-mappings/1/?format=json")
         json_response = json.loads(response.content)
 
         # Assert
-        assert "sentences" in json_response
+        assert json_response["id"] == 1
         assert len(json_response["sentences"][0]["mappings"]) == 1
 
-    def test_export_docx_report(self, logged_in_client, mapping):
+    def test_get_docx(self, logged_in_client, mapping):
         """
         Check that something that looks like a Word doc was returned.
 
         There are separate unit tests for the doc's content.
         """
         # Act
-        response = logged_in_client.get("/api/report-export/1/?type=docx")
-        data = list(response.streaming_content)
+        response = logged_in_client.get("/api/report-mappings/1/?format=docx")
+        data = response.content
 
         # Assert
-        assert data[0].startswith(b"PK\x03\x04")
+        assert data.startswith(b"PK\x03\x04")
 
     def test_bootstrap_training_data_can_be_posted_as_json_report(
         self, logged_in_client
@@ -286,7 +286,7 @@ class TestReportExport:
 
         # Act
         response = logged_in_client.post(
-            "/api/report-export/", json_string, content_type="application/json"
+            "/api/report-mappings/", json_string, content_type="application/json"
         )
 
         # Assert
@@ -295,7 +295,7 @@ class TestReportExport:
     def test_report_export_update_not_implemented(self, logged_in_client):
         # Act
         response = logged_in_client.post(
-            "/api/report-export/1/", "{}", content_type="application/json"
+            "/api/report-mappings/1/", "{}", content_type="application/json"
         )
 
         # Assert
@@ -311,7 +311,7 @@ class TestReportExport:
     def test_get_reports_by_doc_id(self, logged_in_client, report_with_document):
         # Act
         doc_id = report_with_document.document.id
-        response = logged_in_client.get(f"/api/report-export/?doc-id={doc_id}")
+        response = logged_in_client.get(f"/api/report-mappings/?doc-id={doc_id}")
         json_response = json.loads(response.content)
 
         # Assert


### PR DESCRIPTION
JSON exports were being rendered through an HTML template due to
content negotiation in the browser (e.g. Accept:text/html). This commit
forces the renderer to use JSON regardless of content negotiation and
also cleans up the json and docx export code.