### PR TITLE
Bump pandas to 1.2.5. Fixes #192 (support for arm64/Apple M2)

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -7,7 +7,7 @@ django==3.2.16
 faker==6.5.0
 gunicorn==20.1.0
 nltk==3.6.7
-pandas==1.2.3
+pandas==1.2.5
 pdfplumber==0.6.0
 python-docx==0.8.10
 scikit-learn==1.0.2


### PR DESCRIPTION
Bump dependency for pandas from 1.2.3 to 1.2.5 in order to make the docker image build with [lima](https://github.com/lima-vm/lima) on Apple M2 (arm64). Fixes #192 .