### PR TITLE
modified nginx image on docker-compose.yml

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       - tram:/tram/data
       - tram_static:/tram/src/tram/staticfiles
   nginx:
-    image: ghcr.io/center-for-threat-informed-defense/tram:latest
+    image: ghcr.io/center-for-threat-informed-defense/tram-nginx:latest
     ports:
       - "8000:80"
     volumes:


### PR DESCRIPTION
The docker-compose.yml file was missing the nginx image for tram. Without this image, the app won't start when you install it following the steps in the installation guide. With this change, the bug will be fixed. 