### PR TITLE
Update for Compatibility with Docker Compose v2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,19 +56,19 @@ build-container: venv ## Build container image
 		-f docker/Dockerfile.nginx . --label "org.opencontainers.image.revision=$(GIT_HASH)"
 
 .PHONY: start-container
-start-container: ## Start container via docker-compose, runs ctidorg/tram:latest image by default
-	docker-compose -f docker/docker-compose.yml up -d
+start-container: ## Start container via docker compose, runs ctidorg/tram:latest image by default
+	docker compose -f docker/docker-compose.yml up -d
 	@echo "Waiting for container to start..."
-	@echo "To stop the container, run: make stop-container, or, docker-compose -f docker/docker-compose.yml down"
-	@echo "To view container logs, run make container-logs, or, docker-compose -f docker/docker-compose.yml logs -f"
+	@echo "To stop the container, run: make stop-container, or, docker compose -f docker/docker-compose.yml down"
+	@echo "To view container logs, run make container-logs, or, docker compose -f docker/docker-compose.yml logs -f"
 
 .PHONY: stop-container
 stop-container: ## Stop container via docker-compose
-	docker-compose -f docker/docker-compose.yml down
+	docker compose -f docker/docker-compose.yml down
 
 .PHONY: container-logs
 container-logs: ## Print container logs
-	docker-compose -f docker/docker-compose.yml logs -f
+	docker compose -f docker/docker-compose.yml logs -f
 
 .PHONY: clean
 clean: ## Clean up pycache files

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,7 +6,6 @@
 #  - ALLOWED_HOSTS is a list of hosts allowed to connect to the Django server (in settings.py)
 #  - SECRET_KEY is generated at startup to a random value. Set SECRET_KEY env variable for tram service below
 #               to use a static value.
-version: '3.5'
 services:
   tram:
     image: ghcr.io/center-for-threat-informed-defense/tram:latest


### PR DESCRIPTION
This Pull Request has been created because I found some errors installing TRAM container images with Docker Compose v2.

#### (1) docker-compose: No such file or directory
This error occurs when starting TRAM container images from the `start-container` task in Makefile.

For the error details, see the following:
```sh
$ make start-container
docker-compose -f docker/docker-compose.yml up -d
make: docker-compose: No such file or directory
make: *** [start-container] Error 1
```

It uses Docker Compose version v2.29.7 which is installed by Docker Desktop on Mac.
The recommended command-line syntax for Docker Compose v2 is `docker compose`.
https://docs.docker.com/compose/releases/migrate/#what-are-the-differences-between-compose-v1-and-compose-v2

This Pull Request changes the compose command to replace `docker-compose` with `docker compose`.

##### Additional information
The following Wiki page will also need similar changes.
(If this PR is merged, please update the Wiki accordingly.)
https://github.com/center-for-threat-informed-defense/tram/wiki/Installation


#### (2) Compose file: Version top-level element (obsolete)
This warning occurs when starting TRAM container images using `docker/docker-compose.yml`.

The warning details following:
```sh
$ docker compose up
WARN[0000] /Users/username/tram-docker/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 
```

The cause is that the version attribute has been obsoleted.
https://docs.docker.com/reference/compose-file/version-and-name/#version-top-level-element-obsolete


This Pull Request changes to remove the obsolete attribute of `version`.