### PR TITLE
Migrate tram Container to Ubuntu 22.04 and Upgrade Dependencies to Support Python 3.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     name: TRAM GitHub Action Tests
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v2
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
+        python-version: '3.10'
     - name: Install and update essential dependencies
       run: |
         pip install -U pip setuptools

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 #
 #  Simple build command: `docker build -t [repo_name]/tram:[version] .`
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 # OCI labels
 LABEL "org.opencontainers.image.title"="TRAM"
@@ -86,7 +86,7 @@ ENV LC_ALL=C.UTF-8 LANG=C.UTF-8 \
     PATH=/tram/.venv/bin:${PATH}
 
 # flush all output immediately
-ENV PYTHONUNBUFFERED 1
+ENV PYTHONUNBUFFERED=1
 
 WORKDIR /tram
 

--- a/docker/Dockerfile.nginx
+++ b/docker/Dockerfile.nginx
@@ -1,4 +1,4 @@
-FROM nginx:1.21.5-alpine
+FROM nginx:1.27.3-alpine
 
 # OCI labels
 LABEL "org.opencontainers.image.title"="TRAM"

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -4,9 +4,10 @@ django-picklefield==3.1
 djangorestframework==3.14.0
 djangorestframework-simplejwt==5.2.2
 django==3.2.20
-faker==6.5.0
+faker==15.3.4
 gunicorn==20.1.0
 nltk==3.8.1
+numpy==1.24.4
 pandas==2.0.2
 pdfplumber==0.9.0
 python-docx==0.8.11

--- a/tox.ini
+++ b/tox.ini
@@ -36,4 +36,4 @@ testpaths =
 
 [gh-actions]
 python =
-    3.9: tram, bandit, flake8, safety
+    3.10: tram, bandit, flake8, safety


### PR DESCRIPTION
This Pull Request updates the base image of the `tram` container from Ubuntu 20.04 to 22.04, as Ubuntu 20.04 will reach its End of Life (EoL) in April 2025.
Additionally, the `tram-nginx` container has been updated to use the latest version of Nginx (1.27).

Since the Python version installed in Ubuntu 22.04 defaults to 3.10, the dependencies have been updated and the Python version used in tests has been adjusted to ensure compatibility with Python 3.10.

### Changes
- tram
  - Base image updated: `ubuntu:20.04` -> `ubuntu:22.04`
- tram-nginx
  - Nginx version updated: `nginx:1.21.5-alpine` -> `nginx:1.27.3-alpine`

### Additional Information

The EoL schedule for Ubuntu 20.04 is as follows:
https://ubuntu.com/about/release-cycle

- 20.04 LTS (Focal Fossa)
  - End of Standard Support: April 2025
